### PR TITLE
chore: change status to CG-DRAFT

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2,7 +2,7 @@
 Title: Get Installed Related Apps API
 Shortname: get-installed-related-apps
 Level: 1
-Status: ED
+Status: CG-DRAFT
 Group: wicg
 URL: https://wicg.github.io/get-installed-related-apps/spec/
 Editor: Rayan Kanso, Google, rayankans@google.com


### PR DESCRIPTION
To distinguish from W3C specs, we tend to only use "ED" only once a spec is adopted by a W3C working group.